### PR TITLE
[8.0][IMP] partner_firstname: separate name from last/first name

### DIFF
--- a/partner_firstname/__init__.py
+++ b/partner_firstname/__init__.py
@@ -19,3 +19,4 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from . import models
+from . import wizards

--- a/partner_firstname/__openerp__.py
+++ b/partner_firstname/__openerp__.py
@@ -32,10 +32,12 @@
     'website': 'https://odoo-community.org',
     'depends': ['base_setup'],
     'data': [
+        'wizards/res_partner_split_name_wizard_view.xml',
+
         'views/base_config_view.xml',
         'views/res_partner.xml',
         'views/res_user.xml',
-        'data/res_partner.yml',
+        # 'data/res_partner.yml',
     ],
     'demo': [],
     'test': [],

--- a/partner_firstname/i18n/it.po
+++ b/partner_firstname/i18n/it.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: partner-contact (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-07-03 00:45+0000\n"
-"PO-Revision-Date: 2016-07-02 21:38+0000\n"
+"PO-Revision-Date: 2018-12-29 11:22+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Italian (http://www.transifex.com/oca/OCA-partner-contact-8-0/"
 "language/it/)\n"
@@ -21,25 +21,118 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: partner_firstname
+#: view:res.partner.split_name_wizard:partner_firstname.res_partner_split_name_wizard_form_view
+msgid "Cancel"
+msgstr "Annulla"
+
+#. module: partner_firstname
+#: field:res.partner.split_name_wizard,create_uid:0
+msgid "Created by"
+msgstr ""
+
+#. module: partner_firstname
+#: field:res.partner.split_name_wizard,create_date:0
+msgid "Created on"
+msgstr ""
+
+#. module: partner_firstname
+#: field:res.partner.split_name_wizard,display_name:0
+msgid "Display Name"
+msgstr ""
+
+#. module: partner_firstname
 #: code:addons/partner_firstname/models/exceptions.py:25
 #, python-format
 msgid "Error(s) with partner %d's name."
 msgstr "Errore(i) con il nome del partner %d."
 
 #. module: partner_firstname
-#: field:res.partner,firstname:0
-msgid "First name"
-msgstr "Nome"
+#: code:addons/partner_firstname/wizards/res_partner_split_name_wizard.py:27
+#: selection:res.partner.split_name_wizard,split_mode:0
+#, python-format
+msgid "First Middle/Last last"
+msgstr "Nome nome/Cognome cognome"
+
+#. module: partner_firstname
+#: code:addons/partner_firstname/wizards/res_partner_split_name_wizard.py:25
+#: selection:res.partner.split_name_wizard,split_mode:0
+#, python-format
+msgid "First middle/Last"
+msgstr "Nome nome/Cognome"
+
+#. module: partner_firstname
+#: code:addons/partner_firstname/wizards/res_partner_split_name_wizard.py:21
+#: selection:res.partner.split_name_wizard,split_mode:0
+#, python-format
+msgid "First/Last"
+msgstr "Nome/Cognome"
+
+#. module: partner_firstname
+#: code:addons/partner_firstname/wizards/res_partner_split_name_wizard.py:26
+#: selection:res.partner.split_name_wizard,split_mode:0
+#, python-format
+msgid "First/Last last"
+msgstr "Nome/Cognome cognome"
+
+#. module: partner_firstname
+#: code:addons/partner_firstname/wizards/res_partner_split_name_wizard.py:18
+#: field:res.partner.split_name_wizard,split_mode:0
+#, python-format
+msgid "Format"
+msgstr "Formato"
+
+#. module: partner_firstname
+#: field:res.partner.split_name_wizard,id:0
+msgid "ID"
+msgstr "ID"
 
 #. module: partner_firstname
 #: view:res.partner:partner_firstname.view_partner_form_firstname
 msgid "Is a Company?"
-msgstr "È un'azienda?"
+msgstr "E' un'azienda?"
 
 #. module: partner_firstname
-#: field:res.partner,lastname:0
-msgid "Last name"
-msgstr "Cognome"
+#: field:res.partner.split_name_wizard,__last_update:0
+msgid "Last Modified on"
+msgstr "Last Modified on"
+
+#. module: partner_firstname
+#: field:res.partner.split_name_wizard,write_uid:0
+msgid "Last Updated by"
+msgstr "Last Updated by"
+
+#. module: partner_firstname
+#: field:res.partner.split_name_wizard,write_date:0
+msgid "Last Updated on"
+msgstr "Last Updated on"
+
+#. module: partner_firstname
+#: code:addons/partner_firstname/wizards/res_partner_split_name_wizard.py:23
+#: selection:res.partner.split_name_wizard,split_mode:0
+#, python-format
+msgid "Last last/First"
+msgstr "Cognome cognome/Nome"
+
+#. module: partner_firstname
+#: code:addons/partner_firstname/wizards/res_partner_split_name_wizard.py:24
+#: selection:res.partner.split_name_wizard,split_mode:0
+#, python-format
+msgid "Last last/First Middle"
+msgstr "Cognome cognome/Nome nome"
+
+#. module: partner_firstname
+#: code:addons/partner_firstname/wizards/res_partner_split_name_wizard.py:20
+#: selection:res.partner.split_name_wizard,split_mode:0
+#, python-format
+msgid "Last/First"
+msgstr "Cognome/Nome"
+
+#. module: partner_firstname
+#: code:addons/partner_firstname/wizards/res_partner_split_name_wizard.py:22
+#: selection:res.partner.split_name_wizard,split_mode:0
+#, python-format
+msgid "Last/First Middle"
+msgstr "Cognome/Nome nome"
 
 #. module: partner_firstname
 #: code:addons/partner_firstname/models/exceptions.py:22
@@ -48,9 +141,19 @@ msgid "No name is set."
 msgstr "Nessun nome impostato."
 
 #. module: partner_firstname
+#: view:res.partner.split_name_wizard:partner_firstname.res_partner_split_name_wizard_form_view
+msgid "Note:"
+msgstr "Note:"
+
+#. module: partner_firstname
+#: view:res.partner.split_name_wizard:partner_firstname.res_partner_split_name_wizard_form_view
+msgid "Once you choose the split mode and confirm, the operation cannot be undone."
+msgstr "Quando scegli la modalità di separazione e confermi, l'operazione non può essere annullata."
+
+#. module: partner_firstname
 #: help:base.config.settings,partner_names_order:0
 msgid "Order to compose partner fullname"
-msgstr ""
+msgstr "Ordine per comporre il nome completo del partner"
 
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_partner
@@ -58,38 +161,54 @@ msgid "Partner"
 msgstr "Partner"
 
 #. module: partner_firstname
+#: field:res.partner.split_name_wizard,partner_ids:0
+msgid "Partner ids"
+msgstr "Partners"
+
+#. module: partner_firstname
 #: field:base.config.settings,partner_names_order:0
 msgid "Partner names order"
-msgstr ""
+msgstr "Ordine dei nomi dei partner"
 
 #. module: partner_firstname
 #: field:base.config.settings,partner_names_order_changed:0
 msgid "Partner names order changed"
-msgstr ""
+msgstr "L'ordine del nome del partner è cambiato"
 
 #. module: partner_firstname
 #: view:base.config.settings:partner_firstname.view_general_configuration
 msgid "Recalculate names"
-msgstr ""
+msgstr "Ricalcola nomi"
 
 #. module: partner_firstname
 #: view:base.config.settings:partner_firstname.view_general_configuration
-msgid ""
-"Recalculate names for all partners. This process could take so much time if "
-"there are more than 10,000 active partners"
-msgstr ""
+msgid "Recalculate names for all partners. This process could take so much time if there are more than 10,000 active partners"
+msgstr "Ricalcola nomi per tutti i partner. Questo processo può richiedere molto tempo se ci sono più di 10,000 partner attivi"
 
 #. module: partner_firstname
-#: view:res.users:partner_firstname.view_users_form
-msgid "True"
-msgstr "Vero"
+#: code:addons/partner_firstname/wizards/res_partner_split_name_wizard.py:9
+#: model:ir.model,name:partner_firstname.model_res_partner_split_name_wizard
+#, python-format
+msgid "Split Name Wizard"
+msgstr "Wizard separa nome"
 
 #. module: partner_firstname
-#: view:res.partner:partner_firstname.view_partner_form_firstname
-#: view:res.partner:partner_firstname.view_partner_simple_form_firstname
-msgid ""
-"{\n"
-"                    'readonly': [('is_company', '=', False)],\n"
-"                    'required': [('is_company', '=', True)]\n"
-"                }"
-msgstr ""
+#: view:res.partner.split_name_wizard:partner_firstname.res_partner_split_name_wizard_form_view
+msgid "Split name"
+msgstr "Separa nome"
+
+#. module: partner_firstname
+#: view:res.partner.split_name_wizard:partner_firstname.res_partner_split_name_wizard_form_view
+msgid "Split partner name"
+msgstr "Separa nome partner"
+
+#. module: partner_firstname
+#: model:ir.actions.act_window,name:partner_firstname.action_res_partner_split_name_wizard
+msgid "action.res.partner.split.name.wizard"
+msgstr "action.res.partner.split.name.wizard"
+
+#. module: partner_firstname
+#: view:res.partner.split_name_wizard:partner_firstname.res_partner_split_name_wizard_form_view
+msgid "or"
+msgstr "oppure"
+

--- a/partner_firstname/i18n/partner_firstname.pot
+++ b/partner_firstname/i18n/partner_firstname.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-12-29 11:22+0000\n"
+"PO-Revision-Date: 2018-12-29 11:22+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -14,14 +16,69 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: partner_firstname
+#: view:res.partner.split_name_wizard:partner_firstname.res_partner_split_name_wizard_form_view
+msgid "Cancel"
+msgstr ""
+
+#. module: partner_firstname
+#: field:res.partner.split_name_wizard,create_uid:0
+msgid "Created by"
+msgstr ""
+
+#. module: partner_firstname
+#: field:res.partner.split_name_wizard,create_date:0
+msgid "Created on"
+msgstr ""
+
+#. module: partner_firstname
+#: field:res.partner.split_name_wizard,display_name:0
+msgid "Display Name"
+msgstr ""
+
+#. module: partner_firstname
 #: code:addons/partner_firstname/models/exceptions.py:25
 #, python-format
 msgid "Error(s) with partner %d's name."
 msgstr ""
 
 #. module: partner_firstname
-#: field:res.partner,firstname:0
-msgid "First name"
+#: code:addons/partner_firstname/wizards/res_partner_split_name_wizard.py:27
+#: selection:res.partner.split_name_wizard,split_mode:0
+#, python-format
+msgid "First Middle/Last last"
+msgstr ""
+
+#. module: partner_firstname
+#: code:addons/partner_firstname/wizards/res_partner_split_name_wizard.py:25
+#: selection:res.partner.split_name_wizard,split_mode:0
+#, python-format
+msgid "First middle/Last"
+msgstr ""
+
+#. module: partner_firstname
+#: code:addons/partner_firstname/wizards/res_partner_split_name_wizard.py:21
+#: selection:res.partner.split_name_wizard,split_mode:0
+#, python-format
+msgid "First/Last"
+msgstr ""
+
+#. module: partner_firstname
+#: code:addons/partner_firstname/wizards/res_partner_split_name_wizard.py:26
+#: selection:res.partner.split_name_wizard,split_mode:0
+#, python-format
+msgid "First/Last last"
+msgstr ""
+
+#. module: partner_firstname
+#: code:addons/partner_firstname/wizards/res_partner_split_name_wizard.py:18
+#: field:res.partner.split_name_wizard,split_mode:0
+#, python-format
+msgid "Format"
+msgstr ""
+
+#. module: partner_firstname
+#: field:res.partner.split_name_wizard,id:0
+msgid "ID"
 msgstr ""
 
 #. module: partner_firstname
@@ -30,14 +87,62 @@ msgid "Is a Company?"
 msgstr ""
 
 #. module: partner_firstname
-#: field:res.partner,lastname:0
-msgid "Last name"
+#: field:res.partner.split_name_wizard,__last_update:0
+msgid "Last Modified on"
+msgstr ""
+
+#. module: partner_firstname
+#: field:res.partner.split_name_wizard,write_uid:0
+msgid "Last Updated by"
+msgstr ""
+
+#. module: partner_firstname
+#: field:res.partner.split_name_wizard,write_date:0
+msgid "Last Updated on"
+msgstr ""
+
+#. module: partner_firstname
+#: code:addons/partner_firstname/wizards/res_partner_split_name_wizard.py:23
+#: selection:res.partner.split_name_wizard,split_mode:0
+#, python-format
+msgid "Last last/First"
+msgstr ""
+
+#. module: partner_firstname
+#: code:addons/partner_firstname/wizards/res_partner_split_name_wizard.py:24
+#: selection:res.partner.split_name_wizard,split_mode:0
+#, python-format
+msgid "Last last/First Middle"
+msgstr ""
+
+#. module: partner_firstname
+#: code:addons/partner_firstname/wizards/res_partner_split_name_wizard.py:20
+#: selection:res.partner.split_name_wizard,split_mode:0
+#, python-format
+msgid "Last/First"
+msgstr ""
+
+#. module: partner_firstname
+#: code:addons/partner_firstname/wizards/res_partner_split_name_wizard.py:22
+#: selection:res.partner.split_name_wizard,split_mode:0
+#, python-format
+msgid "Last/First Middle"
 msgstr ""
 
 #. module: partner_firstname
 #: code:addons/partner_firstname/models/exceptions.py:22
 #, python-format
 msgid "No name is set."
+msgstr ""
+
+#. module: partner_firstname
+#: view:res.partner.split_name_wizard:partner_firstname.res_partner_split_name_wizard_form_view
+msgid "Note:"
+msgstr ""
+
+#. module: partner_firstname
+#: view:res.partner.split_name_wizard:partner_firstname.res_partner_split_name_wizard_form_view
+msgid "Once you choose the split mode and confirm, the operation cannot be undone."
 msgstr ""
 
 #. module: partner_firstname
@@ -48,6 +153,11 @@ msgstr ""
 #. module: partner_firstname
 #: model:ir.model,name:partner_firstname.model_res_partner
 msgid "Partner"
+msgstr ""
+
+#. module: partner_firstname
+#: field:res.partner.split_name_wizard,partner_ids:0
+msgid "Partner ids"
 msgstr ""
 
 #. module: partner_firstname
@@ -71,16 +181,29 @@ msgid "Recalculate names for all partners. This process could take so much time 
 msgstr ""
 
 #. module: partner_firstname
-#: view:res.users:partner_firstname.view_users_form
-msgid "True"
+#: code:addons/partner_firstname/wizards/res_partner_split_name_wizard.py:9
+#: model:ir.model,name:partner_firstname.model_res_partner_split_name_wizard
+#, python-format
+msgid "Split Name Wizard"
 msgstr ""
 
 #. module: partner_firstname
-#: view:res.partner:partner_firstname.view_partner_form_firstname
-#: view:res.partner:partner_firstname.view_partner_simple_form_firstname
-msgid "{\n"
-"                    'readonly': [('is_company', '=', False)],\n"
-"                    'required': [('is_company', '=', True)]\n"
-"                }"
+#: view:res.partner.split_name_wizard:partner_firstname.res_partner_split_name_wizard_form_view
+msgid "Split name"
+msgstr ""
+
+#. module: partner_firstname
+#: view:res.partner.split_name_wizard:partner_firstname.res_partner_split_name_wizard_form_view
+msgid "Split partner name"
+msgstr ""
+
+#. module: partner_firstname
+#: model:ir.actions.act_window,name:partner_firstname.action_res_partner_split_name_wizard
+msgid "action.res.partner.split.name.wizard"
+msgstr ""
+
+#. module: partner_firstname
+#: view:res.partner.split_name_wizard:partner_firstname.res_partner_split_name_wizard_form_view
+msgid "or"
 msgstr ""
 

--- a/partner_firstname/views/base_config_view.xml
+++ b/partner_firstname/views/base_config_view.xml
@@ -2,33 +2,36 @@
 <!-- © 2015 Antiun Ingenieria S.L. - Antonio Espinosa
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
 <openerp>
-<data>
+    <data>
 
-<record id="view_general_configuration" model="ir.ui.view">
-    <field name="name">Add partner_names_order config parameter</field>
-    <field name="model">base.config.settings</field>
-    <field name="inherit_id" ref="base_setup.view_general_configuration"/>
-    <field name="arch" type="xml">
-        <xpath expr="//label[@string='Email']/.." position='after'>
-            <group>
-                <label for="partner_names_order" />
-                <div>
-                    <div>
-                        <field name="partner_names_order" class="oe_inline" />
-                        <field name="partner_names_order_changed" invisible="1"/>
-                        <button name="action_recalculate_partners_name"
-                                string="Recalculate names"
-                                icon="gtk-execute"
-                                type="object"
-                                help="Recalculate names for all partners. This process could take so much time if there are more than 10,000 active partners"
-                                attrs="{'invisible': [('partner_names_order_changed', '=', True)]}"/>
-                    </div>
-                </div>
-            </group>
-        </xpath>
-    </field>
-</record>
+        <record id="view_general_configuration" model="ir.ui.view">
+            <field name="name">Add partner_names_order config parameter</field>
+            <field name="model">base.config.settings</field>
+            <field name="inherit_id"
+                   ref="base_setup.view_general_configuration"/>
+            <field name="arch" type="xml">
+                <xpath expr="//label[@string='Email']/.." position='after'>
+                    <group>
+                        <label for="partner_names_order"/>
+                        <div>
+                            <div>
+                                <field name="partner_names_order"
+                                       class="oe_inline"/>
+                                <field name="partner_names_order_changed"
+                                       invisible="1"/>
+                                <button name="action_recalculate_partners_name"
+                                        string="Recalculate names"
+                                        icon="gtk-execute"
+                                        type="object"
+                                        help="Recalculate names for all partners. This process could take so much time if there are more than 10,000 active partners"
+                                        attrs="{'invisible': [('partner_names_order_changed', '=', True)]}"/>
+                            </div>
+                        </div>
+                    </group>
+                </xpath>
+            </field>
+        </record>
 
 
-</data>
+    </data>
 </openerp>

--- a/partner_firstname/views/res_partner.xml
+++ b/partner_firstname/views/res_partner.xml
@@ -1,98 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
-<data>
+    <data>
 
-<record id="view_partner_simple_form_firstname" model="ir.ui.view">
-    <field name="name">Add firstname and lastname</field>
-    <field name="model">res.partner</field>
-    <field name="inherit_id" ref="base.view_partner_simple_form"/>
-    <field name="arch" type="xml">
-        <data>
-            <xpath expr="//field[@name='name']" position="attributes">
-                <attribute name="attrs">{
-                    'readonly': [('is_company', '=', False)],
-                    'required': [('is_company', '=', True)]
-                }</attribute>
-            </xpath>
+        <record id="view_partner_simple_form_firstname" model="ir.ui.view">
+            <field name="name">Add firstname and lastname</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_partner_simple_form"/>
+            <field name="arch" type="xml">
+                <data>
+                    <field name="email" position="before">
+                        <field name="lastname" attrs="{'invisible': [('is_company', '=', True)]}" />
+                        <field name="firstname" attrs="{'invisible': [('is_company', '=', True)]}" />
+                    </field>
+                </data>
+            </field>
+        </record>
 
-            <xpath expr="//field[@name='category_id']" position="before">
-                <group attrs="{'invisible': [('is_company', '=', True)]}">
-                    <field name="lastname" attrs=
-                        "{'required': [('firstname', '=', False),
-                                       ('is_company', '=', False)]}"/>
-                    <field name="firstname" attrs=
-                        "{'required': [('lastname', '=', False),
-                                       ('is_company', '=', False)]}"/>
-                </group>
-            </xpath>
-        </data>
-    </field>
-</record>
+        <record id="view_partner_form_firstname" model="ir.ui.view">
+            <field name="name">Add firstname and surnames</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_partner_form"/>
+            <field name="arch" type="xml">
+                <data>
+                    <!--&lt;!&ndash; TODO Move this header in another module! &ndash;&gt;-->
+                    <!--<xpath expr="//sheet[1]" position="before">-->
+                        <!--<header>-->
+                            <!--<button name="%(action_res_partner_split_name_wizard)d"-->
+                                    <!--string="Split name"-->
+                                    <!--type="action"-->
+                                    <!--attrs="{'invisible': [('is_company', '=', True)]}" />-->
+                        <!--</header>-->
+                    <!--</xpath>-->
+                     <label for="street" position="before">
+                        <field name="lastname" attrs="{'invisible': [('is_company', '=', True)]}" />
+                        <field name="firstname" attrs="{'invisible': [('is_company', '=', True)]}" />
+                    </label>
 
-<record id="view_partner_form_firstname" model="ir.ui.view">
-    <field name="name">Add firstname and surnames</field>
-    <field name="model">res.partner</field>
-    <field name="inherit_id" ref="base.view_partner_form"/>
-    <field name="arch" type="xml">
-        <data>
-            <xpath expr="//field[@name='name']" position="attributes">
-                <attribute name="attrs">{
-                    'readonly': [('is_company', '=', False)],
-                    'required': [('is_company', '=', True)]
-                }</attribute>
-            </xpath>
+                    <!-- Modify inner contact form of child_ids -->
+                    <xpath expr="//field[@name='child_ids']/form//label[@for='street']" position="before">
+                        <field name="lastname" attrs="{'invisible': [('is_company', '=', True)]}" />
+                        <field name="firstname" attrs="{'invisible': [('is_company', '=', True)]}" />
+                    </xpath>
 
-            <xpath expr="//field[@name='category_id']" position="before">
-                <group attrs="{'invisible': [('is_company', '=', True)]}">
-                    <field name="lastname" attrs=
-                        "{'required': [('firstname', '=', False),
-                                       ('is_company', '=', False)]}"/>
-                    <field name="firstname" attrs=
-                        "{'required': [('lastname', '=', False),
-                                       ('is_company', '=', False)]}"/>
-                </group>
-            </xpath>
+                    <xpath expr="//field[@name='child_ids']/form//label[@for='name']"
+                           position="before">
+                        <div class="oe_edit_only">
+                            <field name="is_company"
+                                   on_change="onchange_type(is_company)"/>
+                            <label for="is_company"
+                                   string="Is a Company?"/>
+                        </div>
+                    </xpath>
 
-            <!-- Modify inner contact form of child_ids -->
-            <xpath expr="//field[@name='child_ids']/form
-                         //field[@name='category_id']"
-                   position="before">
-                <group attrs="{'invisible': [('is_company', '=', True)]}">
-                    <field name="lastname" attrs=
-                        "{'required': [('firstname', '=', False),
-                                       ('is_company', '=', False)]}"/>
-                    <field name="firstname" attrs=
-                        "{'required': [('lastname', '=', False),
-                                       ('is_company', '=', False)]}"/>
-                </group>
-            </xpath>
+                </data>
+            </field>
+        </record>
 
-            <xpath expr="//field[@name='child_ids']/form
-                         //field[@name='category_id']"
-                   position="attributes">
-                <attribute name="style"/>
-            </xpath>
-
-            <xpath expr="//field[@name='child_ids']/form//label[@for='name']"
-                   position="before">
-                <div class="oe_edit_only">
-                    <field name="is_company"
-                           on_change="onchange_type(is_company)"/>
-                    <label for="is_company"
-                           string="Is a Company?"/>
-                </div>
-            </xpath>
-
-            <xpath expr="//field[@name='child_ids']/form//field[@name='name']"
-                   position="attributes">
-                <attribute name="attrs">{
-                    'readonly': [('is_company', '=', False)],
-                    'required': [('is_company', '=', True)]
-                }</attribute>
-            </xpath>
-        </data>
-  </field>
-</record>
-
-</data>
+    </data>
 </openerp>

--- a/partner_firstname/views/res_user.xml
+++ b/partner_firstname/views/res_user.xml
@@ -1,32 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
-<data>
+    <data>
 
-<!-- Required before modifying `base.vew_users_form`.
-     https://github.com/odoo/odoo/issues/6324#issuecomment-93534579 -->
-<function model="res.groups" name="update_user_groups_view" />
+        <!-- Required before modifying `base.vew_users_form`.
+             https://github.com/odoo/odoo/issues/6324#issuecomment-93534579 -->
+        <function model="res.groups" name="update_user_groups_view"/>
 
-<record id="view_users_form" model="ir.ui.view">
-    <field name="name">Add firstname and surnames</field>
-    <field name="model">res.users</field>
-    <field name="inherit_id" ref="base.view_users_form"/>
-    <field name="arch" type="xml">
-        <data>
-            <xpath expr="//field[@name='name']" position="attributes">
-                <attribute name="readonly">True</attribute>
-            </xpath>
+        <record id="view_users_form" model="ir.ui.view">
+            <field name="name">Add firstname and surnames</field>
+            <field name="model">res.users</field>
+            <field name="inherit_id" ref="base.view_users_form"/>
+            <field name="arch" type="xml">
+                <data>
 
-            <xpath expr="//field[@name='email']" position="after">
-                <group>
-                    <field name="lastname"
-                           attrs="{'required': [('firstname', '=', False)]}"/>
-                    <field name="firstname"
-                           attrs="{'required': [('lastname', '=', False)]}"/>
-                </group>
-            </xpath>
-        </data>
-  </field>
-</record>
+                    <xpath expr="//field[@name='email']" position="after">
+                        <group>
+                            <field name="lastname" />
+                            <field name="firstname" />
+                        </group>
+                    </xpath>
+                </data>
+            </field>
+        </record>
 
-</data>
+    </data>
 </openerp>

--- a/partner_firstname/wizards/__init__.py
+++ b/partner_firstname/wizards/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+import res_partner_split_name_wizard

--- a/partner_firstname/wizards/res_partner_split_name_wizard.py
+++ b/partner_firstname/wizards/res_partner_split_name_wizard.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+from openerp import models, fields, api
+from openerp.tools.translate import _
+
+
+class ResPartnerSplitNameWizard(models.TransientModel):
+    _name = 'res.partner.split_name_wizard'
+    _description = _('Split Name Wizard')
+
+    partner_ids = fields.Many2many(
+        comodel_name='res.partner',
+        default=lambda self: self._get_partner_ids(),
+        readonly=True
+    )
+
+    split_mode = fields.Selection(
+        string=_('Format'),
+        selection=[
+            ('LF', _('Last/First')),
+            ('FL', _('First/Last')),
+            ('LFM', _('Last/First Middle')),
+            ('L2F', _('Last last/First')),
+            ('L2FM', _('Last last/First Middle')),
+            ('FML', _('First middle/Last')),
+            ('FL2', _('First/Last last')),
+            ('FML2', _('First Middle/Last last'))
+        ],
+        default='LF'
+    )
+
+    @api.model
+    def _get_partner_ids(self):
+        partner_cls = self.env['res.partner']
+        partner_ids = self.env.context.get('active_ids', [])
+        return partner_cls.browse(partner_ids)
+
+    @api.multi
+    def _split_last_first_name(self, partner):
+        self.ensure_one()
+        if not partner.name:
+            return '', ''
+
+        f = partner.name.split(' ')
+        if len(f) == 1:
+            if self.split_mode[0] == 'F':
+                return '', f[0]
+            elif self.split_mode[0] == 'L':
+                return f[0], ''
+        elif len(f) == 2:
+            if self.split_mode[0] == 'F':
+                return f[1], f[0]
+            elif self.split_mode[0] == 'L':
+                return f[0], f[1]
+        elif len(f) == 3:
+            if self.split_mode in ('LFM', 'LF', 'L2FM'):
+                return f[2], '%s %s' % (f[0], f[1])
+            elif self.split_mode in ('FML', 'FL', 'FML2'):
+                return '%s %s' % (f[0], f[1]), f[2]
+            elif self.split_mode == 'L2F':
+                return '%s %s' % (f[0], f[1]), f[2]
+            elif self.split_mode == 'FL2':
+                return '%s %s' % (f[1], f[2]), f[0]
+        else:
+            if self.split_mode[0] == 'F':
+                return '%s %s' % (f[2], f[3]), '%s %s' % (f[0], f[1])
+            elif self.split_mode[0] == 'L':
+                return '%s %s' % (f[0], f[1]), '%s %s' % (f[2], f[3])
+
+        return '', ''
+
+    @api.multi
+    def action_split_name(self):
+        self.ensure_one()
+        for record in self.partner_ids:
+            firstname, lastname = self._split_last_first_name(record)
+            record.firstname = firstname
+            record.lastname = lastname
+
+        return True

--- a/partner_firstname/wizards/res_partner_split_name_wizard_view.xml
+++ b/partner_firstname/wizards/res_partner_split_name_wizard_view.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="res_partner_split_name_wizard_form_view" model="ir.ui.view">
+            <field name="name">Split name</field>
+            <field name="model">res.partner.split_name_wizard</field>
+            <field name="arch" type="xml">
+                <form string="Split partner name">
+                    <group>
+                        <group>
+                            <field name="partner_ids" invisible="1" />
+                            <field name="split_mode" />
+                        </group>
+                        <group></group>
+                    </group>
+                    <p class="oe_grey">
+                        <strong>Note:</strong> Once you choose the split mode and confirm, the operation cannot be undone.
+                    </p>
+                    <footer>
+                        <button name="action_split_name"
+                                string="Split name"
+                                type="object"
+                                class="oe_highlight" />
+                        or
+                        <button string="Cancel" class="oe_link" special="cancel" />
+                    </footer>
+                </form>
+            </field>
+        </record>
+        
+        <record id="action_res_partner_split_name_wizard" model="ir.actions.act_window">
+            <field name="name">action.res.partner.split.name.wizard</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">res.partner.split_name_wizard</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="res_partner_split_name_wizard_form_view"/>
+            <field name="target">new</field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
 [IMP] removed name as computed, in order to have name field separated from first/lastname fields.
 [FIX] simplified form views
 [ADD] new wizard to split Last/First name manually
 [FIX] translations